### PR TITLE
We have warning:

### DIFF
--- a/4a-timeout-with-wait-kwarg.py
+++ b/4a-timeout-with-wait-kwarg.py
@@ -45,7 +45,7 @@ async def main(timeout):
         "ip": "not available"
     }
 
-    futures = [fetch_ip(service) for service in SERVICES]
+    futures = [asyncio.create_task(fetch_ip(service)) for service in SERVICES]
     done, pending = await asyncio.wait(
         futures, timeout=timeout, return_when=FIRST_COMPLETED)
 


### PR DESCRIPTION
4a-timeout-with-wait-kwarg.py:49: DeprecationWarning:
The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8,
and scheduled for removal in Python 3.11.

So we should use asyncio.create_task instead pass bare function